### PR TITLE
Extract resolver from query and inject formatted AQL 

### DIFF
--- a/client/aqlQueryParser.js
+++ b/client/aqlQueryParser.js
@@ -1,0 +1,45 @@
+import { v4 as uuidv4 } from 'uuid';
+
+/* aqlQueryParser uses classic iterative parsing to extract the resolver from the query, 
+inject a correctly formatted AQL containing the resolver into the body of the query arguments.
+
+TODO: 
+- Line 35, Pass in userToken
+- Update necessary to accept non-string query args
+*/
+
+function aqlQueryParser(queryString) {
+  let returnQuery = '';
+  let inResolver = false;
+  let resolver = '';
+  let inArgs = false;
+  let resolverFound = false;
+  for (let i = 0; i < queryString.length; i++) {
+    if (inResolver && (queryString[i] === '{' || queryString[i] === '(')) {
+      resolverFound = true;
+      inResolver = false;
+    }
+    if (inResolver) {
+      resolver += queryString[i];
+    }
+    if (queryString[i] === '(') {
+      inArgs = true;
+    }
+    if (queryString[i] === ')' && inArgs) {
+      //inject aql
+      returnQuery += `, aql: {mutationSendTime: "${Date.now()}",
+      mutationReceived: "",
+      subscriberReceived: "",
+      mutationId: "${uuidv4()}",
+      resolver: "${resolver}",
+      userToken: "testingHooks"}`;
+    }
+    if (queryString[i] === '{' && !resolverFound) {
+      inResolver = true;
+    }
+    returnQuery += queryString[i];
+  }
+  return returnQuery;
+}
+
+export default aqlQueryParser;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Extract resolver from query and inject formatted AQL 
## Approach
aqlQueryParser.js uses classic iterative parsing to extract the resolver from the query, inject a correctly formatted AQL containing the resolver into the body of the query arguments.

TODO: 
- Line 35, Pass in userToken
- Update necessary to accept non-string query args

Co-authored-by Julie Pinchak <jpinchak@gmail.com>