### PR TITLE
Create front-end hooks and enable userToken on all back-end methods/modules

### DIFF
--- a/client/useAqlMutation.js
+++ b/client/useAqlMutation.js
@@ -1,0 +1,25 @@
+import aqlQueryParser from './aqlQueryParser';
+
+/* useAqlMutation is a promisified query hook that takes a GraphQL mutation query formatted 
+as a string, and returns the response from the server. AQL tracking is automatically injected 
+into the body of the request. You can chain methods using .then to control app behavior on 
+resolution of the query. */
+
+function useAqlMutation(query) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: aqlQueryParser(query),
+      }),
+    };
+    console.log(aqlQueryParser(query));
+    fetch(`/graphql`, options)
+      .then((data) => data.json())
+      .then((result) => resolve(result))
+      .catch((err) => console.log(err));
+  });
+}
+
+export default useAqlMutation;

--- a/client/useAqlSubscription.js
+++ b/client/useAqlSubscription.js
@@ -1,0 +1,72 @@
+import { useSubscription, gql } from '@apollo/client';
+import { v4 as uuidv4 } from 'uuid';
+
+function sendAqlToAnalytics(client, subscriptionResolver) {
+  // create final properties on Aql
+  const aqlToSendToDB = client.subscriptionData.data[subscriptionResolver].aql;
+  aqlToSendToDB.subscriberReceived = Date.now();
+  aqlToSendToDB.roundtripTime = `${
+    aqlToSendToDB.subscriberReceived - aqlToSendToDB.mutationSendTime
+  }`;
+
+  // extract variable names for post request
+  const {
+    mutationSendTime,
+    mutationReceived,
+    subscriberReceived,
+    roundtripTime,
+    mutationId,
+    resolver,
+    userToken,
+  } = aqlToSendToDB;
+
+  // create options object for post request that will send Aql to analytics endpoint
+  const options = {
+    method: 'post',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      id: uuidv4(),
+      mutationSendTime,
+      mutationReceived,
+      subscriberReceived,
+      roundtripTime,
+      mutationId,
+      resolver,
+      userToken,
+    }),
+  };
+
+  // send Aql to /analytics
+  fetch(`/analytics`, options).catch((err) => console.log(err));
+}
+
+function useAqlSubscription(query, options, subscriptionResolver) {
+  // make copy of options object
+  const newOptions = { ...options };
+  // if functions are declared in the onSubscriptionData property
+  if (newOptions.onSubscriptionData) {
+    // save the functions and call sendAqlToAnalytics first
+    const holder = newOptions.onSubscriptionData;
+    newOptions.onSubscriptionData = (client) => {
+      sendAqlToAnalytics(client, subscriptionResolver);
+      //holder function to be called
+      holder(client);
+    };
+  } else {
+    // otherwise call sendAqlToAnalytics
+    newOptions.onSubscriptionData = (client) => {
+      sendAqlToAnalytics(client, subscriptionResolver);
+    };
+  }
+  // call useSubscription, passing newOptions object
+  const { data, loading, error } = useSubscription(query, newOptions);
+
+  // return data, loading, error object
+  return {
+    data,
+    loading,
+    error,
+  };
+}
+
+export default useAqlSubscription;

--- a/server/newAqlPayload.js
+++ b/server/newAqlPayload.js
@@ -4,12 +4,13 @@ const newTraqlEntry = require('./newTraqlEntry');
 current time, creates newTraqlEntry for this mutation, and finally returns updated payload. */
 
 function newAqlPayload(payload, args, traql, pubsub) {
-  const newPayload = {...payload};
-  // Update payload to include Aql with mutationReceived property
-  for(let key in newPayload) {
+  const newPayload = { ...payload };
+  // Update payload to include Aql with mutationReceived and userToken property
+  for (let key in newPayload) {
     newPayload[key].aql = {
       ...args.aql,
       mutationReceived: Date.now(),
+      userToken: traql.userToken,
     };
   }
   // Create new entry in Traql for this mutation

--- a/server/newTraqlEntry.js
+++ b/server/newTraqlEntry.js
@@ -5,9 +5,11 @@ function newTraqlEntry(traql, args, pubsub) {
   traql[args.aql.mutationId] = {
     resolver: args.aql.resolver,
     openedTime: Date.now(),
-    expectedNumberOfAqls: Object.keys(pubsub.subscriptions).length / traql.subResolvers,
+    expectedNumberOfAqls: Math.floor(
+      Object.keys(pubsub.subscriptions).length / traql.subResolvers
+    ),
     aqlsReceivedBack: [],
-    userToken: args.aql.userToken,
+    userToken: traql.userToken,
   };
 }
 

--- a/server/traql.js
+++ b/server/traql.js
@@ -3,9 +3,11 @@ Traql will keep track of the number of subscription resolvers in the system,
 which will be used to calculate the number of current subscribers 
 (subscriptions divided by number of subscription resolvers). */
 
-function Traql(resolvers) {
+function Traql(resolvers, userToken) {
   // Create subResolvers property that is equal to number of subscription resolvers in system.
   this.subResolvers = Object.keys(resolvers.Subscription).length;
-};
+  // Create userToken property
+  this.userToken = userToken;
+}
 
 module.exports = Traql;

--- a/server/traqlAudit.js
+++ b/server/traqlAudit.js
@@ -9,9 +9,13 @@ let open = true;
 function traqlAudit(traql) {
   if (open) {
     open = false;
-    if (Object.keys(traql).length > 1) {
+    if (Object.keys(traql).length > 2) {
       for (let key in traql) {
-        if (key !== 'subResolvers' && traql[key].expectedNumberOfAqls >= 1) {
+        if (
+          key !== 'subResolvers' &&
+          key !== 'userToken' &&
+          traql[key].expectedNumberOfAqls >= 1
+        ) {
           if (
             traql[key].expectedNumberOfAqls ===
             traql[key].aqlsReceivedBack.length


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Create front-end hooks and enable userToken on all back-end methods/modules
## Approach
**(create) useAqlSubscription:**
- create useAqlSubscription and enable multiple onSubscription data methods
- create sendAqlToAnalytics function which completes Aql lifecycle and sends Aql to analytics endpoint on reciept of subscription data

**(create) useAqlMutation**
- useAqlMutation function accepts valid GraphQL query and returns a promisified fetch request to GraphQL server
- useAqlMutation function uses aqlQueryParser to inject Aql tracking into query string

**(update) newAqlPayload to create userToken property on Aql**

**(update) newTraqlEntry to create userToken on each Traql entry**

**(update) traql to contain userToken property upon instantiation**

**(update) traqlAudit**
- Traql: ensure Object.keys(traql).length is greater than 2 before continuing with audit
- Traql: do not audit Traql property with name userToken

Co-authored-by Michael O’Halloran <45404541+LordRegis22@users.noreply.github.com>